### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/rlv-incycle/67c9cb1b-40f5-46c3-b747-bb94153b051b/67b92b5f-21b8-4e0c-9255-6a8f9c4bec15/_apis/work/boardbadge/2d783dbf-78a4-4148-adad-3b1c2bcfb2a1)](https://dev.azure.com/rlv-incycle/67c9cb1b-40f5-46c3-b747-bb94153b051b/_boards/board/t/67b92b5f-21b8-4e0c-9255-6a8f9c4bec15/Microsoft.RequirementCategory)
 # Tailwind Traders Website
 
 ![Tailwind Traders Website](Documents/Images/Website.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2288](https://dev.azure.com/rlv-incycle/67c9cb1b-40f5-46c3-b747-bb94153b051b/_workitems/edit/2288). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.